### PR TITLE
Add psalm-pure for static factory methods

### DIFF
--- a/src/Aeon/Calendar/Gregorian/Holidays/GoogleCalendar/CountryCodes.php
+++ b/src/Aeon/Calendar/Gregorian/Holidays/GoogleCalendar/CountryCodes.php
@@ -464,6 +464,8 @@ final class CountryCodes
     public const ZW = 'ZW';
 
     /**
+     * @psalm-pure
+     *
      * @return array<int, string>
      */
     public static function all() : array


### PR DESCRIPTION
Adds missing `psalm-pure` annotation on static factory methods.